### PR TITLE
Fixed Title Screen UI scaling and Screenshots now show newest to oldest

### DIFF
--- a/Assets/Polytope Studio/Lowpoly_Environments/SRP/PT_Nature_Free_URP_10.10.1.unitypackage.meta
+++ b/Assets/Polytope Studio/Lowpoly_Environments/SRP/PT_Nature_Free_URP_10.10.1.unitypackage.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: da738e7716a7c424b8eba26f208307b6
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Polytope Studio/Lowpoly_Environments/SRP/PT_Nature_Free_URP_12.1.10.unitypackage.meta
+++ b/Assets/Polytope Studio/Lowpoly_Environments/SRP/PT_Nature_Free_URP_12.1.10.unitypackage.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7b658bcbdf15638449a47319ee5bdd70
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Polytope Studio/Lowpoly_Environments/SRP/PT_Nature_Free_URP_14.0.9.unitypackage.meta
+++ b/Assets/Polytope Studio/Lowpoly_Environments/SRP/PT_Nature_Free_URP_14.0.9.unitypackage.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: bd960d1781917284bb89077cf66b65fe
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/TerrainAndBird.unity
+++ b/Assets/Scenes/TerrainAndBird.unity
@@ -2252,7 +2252,7 @@ MonoBehaviour:
   m_ChildControlHeight: 0
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
-  m_ReverseArrangement: 0
+  m_ReverseArrangement: 1
 --- !u!114 &705435371
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/TitleScreen.unity
+++ b/Assets/Scenes/TitleScreen.unity
@@ -1705,10 +1705,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_UiScaleMode: 0
+  m_UiScaleMode: 1
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 800, y: 600}
+  m_ReferenceResolution: {x: 1920, y: 1080}
   m_ScreenMatchMode: 0
   m_MatchWidthOrHeight: 0
   m_PhysicalUnit: 3
@@ -3173,7 +3173,7 @@ MonoBehaviour:
   m_ChildControlHeight: 0
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
-  m_ReverseArrangement: 0
+  m_ReverseArrangement: 1
 --- !u!114 &1949909764
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## Summarize what is being added
-Title screen UI scales properly now on different resolutions
-Screenshot Panel now shows screenshots in order of newest to oldest

## Please describe how to test
-Take a couple of screenshots and check them in game, the most recent screenshot should be shown first

## What Week of the 603 cycle is this due in?
-Week 3